### PR TITLE
Change COVID policy and team page

### DIFF
--- a/frontend/src/components/home/Faq.jsx
+++ b/frontend/src/components/home/Faq.jsx
@@ -332,9 +332,9 @@ export default function Faq() {
           </AccordionSummary>
           <AccordionDetails classes={{ root: classes.MuiAccordionDetailroot }}>
             <Typography className={classes.text}>
-              Proof of COVID-19 vaccination and booster shot or proof of exemption must be uploaded
-              to your Profile page when you register for HopHacks. No masks are required, unless you
-              are exempt from vaccination.
+              Proof of FDA or WHO-authorized COVID-19 vaccination or proof of exemption must be
+              uploaded to your Profile page when you register for HopHacks. No masks are required,
+              unless you are exempt from vaccination.
             </Typography>
           </AccordionDetails>
         </Accordion>

--- a/frontend/src/components/home/Team.jsx
+++ b/frontend/src/components/home/Team.jsx
@@ -270,15 +270,7 @@ export default function Team() {
         {value === 1 && (
           <Grid className={classes.team} container>
             <div className={classes.teambox}>
-              <MemberItem
-                imgURL="Elizabeth"
-                memberName="Elizabeth Hsieh"
-                memberTitle="Design Head"
-                linkedin="https://www.linkedin.com/in/elizabeth-hsieh/"
-              />
-            </div>
-            <div className={classes.teambox}>
-              <MemberItem imgURL="Miranda" memberName="Miranda Bian" memberTitle="Design" />
+              <MemberItem imgURL="Miranda" memberName="Miranda Bian" memberTitle="Design Head" />
             </div>
             <div className={classes.teambox}>
               <MemberItem
@@ -374,15 +366,6 @@ export default function Team() {
                 memberName="Dhruv Dubey"
                 memberTitle="Sponsors"
                 linkedin="https://www.linkedin.com/in/dhruv-dubey-51660b1b7/"
-              />
-            </div>
-            <div className={classes.teambox}>
-              <MemberItem
-                imgURL="Sky"
-                memberName="Anthony Sky Ng-Thow-Hing"
-                memberTitle="Sponsors"
-                linkedin="https://www.linkedin.com/in/anthony-sky-ng-thow-hing-9b1352193/"
-                github="https://github.com/skynth"
               />
             </div>
             <div className={classes.teambox}>
@@ -512,7 +495,7 @@ export default function Team() {
                 imgURL="NicholasBowen"
                 memberName="Nicolas Bowen"
                 memberTitle="Palantir"
-                linkedin="https://www.linkedin.com/in/stella-li-1106/"
+                linkedin="https://www.linkedin.com/in/nicholas-bowen24/"
               />
             </div>
             <div className={classes.teambox}>


### PR DESCRIPTION
Changes made
- Amend COVID-19 policy in FAQ to be in accordance with JHU policies
- Make Miranda head of design on design team page (removed Liz)
- Remove Sky from the sponsors team page

DISCLAIMER: My localhost is not compiling, so PULL DOWN and REVIEW to make sure none of my changes crash the website.