### PR TITLE
Enabled cross year accounts

### DIFF
--- a/api/src/resumes.py
+++ b/api/src/resumes.py
@@ -53,27 +53,28 @@ def upload():
 
     # remove old resume
     if ('resume' in user):
-        old_file_name = user['resume']
-        object_name = 'Fall-2024/{}-{}'.format(id, old_file_name)
-        s3.delete_object(Bucket=BUCKET, Key=object_name)
-    
-    eastern = pytz.timezone("America/New_York")
-
-    eventFile = open("event.txt", "r")
-    if (user['resume'] == ""):
-        result = db.users.update_many(
-        {
-            '_id': {'$in': id},
-            'registrations.event' : eventFile.read()
-        },
-        {
-            '$set': {
-                "registrations.$.apply": True,
-                "registrations.$.accept_at": datetime.datetime.utcnow(),
-                "registrations.$.status": "applied"
+        if (user['resume'] == ""):
+            eastern = pytz.timezone("America/New_York")
+            eventFile = open("event.txt", "r")
+            result = db.users.update_many(
+            {
+                '_id': {'$in': id},
+                'registrations.event' : eventFile.read()
+            },
+            {
+                '$set': {
+                    "registrations.$.apply": True,
+                    "registrations.$.apply_at": datetime.datetime.utcnow(),
+                    "registrations.$.status": "applied"
+                }
             }
-        }
-    )
+        )
+        else:
+            old_file_name = user['resume']
+            object_name = 'Fall-2024/{}-{}'.format(id, old_file_name)
+            s3.delete_object(Bucket=BUCKET, Key=object_name)
+    
+
     # TODO make this atomic? what if the file upload doesn't work?
     object_name = 'Fall-2024/{}-{}'.format(id, file_name)
     s3.upload_fileobj(file, BUCKET, object_name)

--- a/frontend/src/components/account/Profile.jsx
+++ b/frontend/src/components/account/Profile.jsx
@@ -173,7 +173,7 @@ const Profile = function Profile(props) {
     const response = await axios.get('/api/registrations/get');
     response.data.registrations.forEach((registration) => {
       if (registration.event === currentEvent) {
-        if (registration.status == 'Email confirmed') {
+        if (registration.status == 'email_confirmed') {
           setStatus(
             'Upload Resume to finish applying. Reload the page to see updated application status.'
           );

--- a/frontend/src/components/account/Profile.jsx
+++ b/frontend/src/components/account/Profile.jsx
@@ -173,6 +173,11 @@ const Profile = function Profile(props) {
     const response = await axios.get('/api/registrations/get');
     response.data.registrations.forEach((registration) => {
       if (registration.event === currentEvent) {
+        if (registration.status == 'Email confirmed') {
+          setStatus(
+            'Upload Resume to finish applying. Reload the page to see updated application status.'
+          );
+        }
         if (registration.rsvp) {
           setStatus(rsvpStatus);
         } else if (registration.accept) {

--- a/frontend/src/components/user_auth/ResetPassword.jsx
+++ b/frontend/src/components/user_auth/ResetPassword.jsx
@@ -15,8 +15,8 @@ export default function PasswordReset(props) {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   // const [attempted, setAttempted] = useState(false);
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
+  // const [password, setPassword] = useState('');
+  // const [confirmPassword, setConfirmPassword] = useState('');
 
   async function reset_password() {
     const myVariable = process.env.REACT_APP_BACKENDURL;
@@ -24,19 +24,19 @@ export default function PasswordReset(props) {
     if (myVariable != '') {
       axios.defaults.baseURL = myVariable;
     }
-    const passwordre = /^(?=.*[0-9])(?=.*[!@#$%^&*)(+=._-])[a-zA-Z0-9!@#$%^&*)(+=._-]{6,25}$/;
+    // const passwordre = /^(?=.*[0-9])(?=.*[!@#$%^&*)(+=._-])[a-zA-Z0-9!@#$%^&*)(+=._-]{6,25}$/;
 
-    if (!password.match(passwordre)) {
-      setMessage(
-        'Please enter a password between 7 to 25 characters which contain at least one numeric digit and a special character.'
-      );
-      return;
-    }
+    // if (!password.match(passwordre)) {
+    //   setMessage(
+    //     'Please enter a password between 7 to 25 characters which contain at least one numeric digit and a special character.'
+    //   );
+    //   return;
+    // }
 
-    if (password != confirmPassword) {
-      setMessage('Confirm password must match with the password');
-      return;
-    }
+    // if (password != confirmPassword) {
+    //   setMessage('Confirm password must match with the password');
+    //   return;
+    // }
 
     try {
       //TODO: need email verification
@@ -62,40 +62,6 @@ export default function PasswordReset(props) {
             style={{ width: '90%' }}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            InputLabelProps={{
-              style: { color: '#061A40' }
-            }}
-            InputProps={{
-              style: { color: '#061A40' }
-            }}
-          />
-        </div>
-        <div className="text-field">
-          <TextField
-            type={'password'}
-            required
-            variant="standard"
-            label="New Password"
-            value={password}
-            style={{ width: '90%' }}
-            onChange={(e) => setPassword(e.target.value)}
-            InputLabelProps={{
-              style: { color: '#061A40' }
-            }}
-            InputProps={{
-              style: { color: '#061A40' }
-            }}
-          />
-        </div>
-        <div className="text-field">
-          <TextField
-            type={'password'}
-            required
-            variant="standard"
-            label="Confirm New Password"
-            value={confirmPassword}
-            style={{ width: '90%' }}
-            onChange={(e) => setConfirmPassword(e.target.value)}
             InputLabelProps={{
               style: { color: '#061A40' }
             }}
@@ -147,37 +113,6 @@ export default function PasswordReset(props) {
             }}
           />
         </div>
-        <TextField
-          type={'password'}
-          required
-          variant="standard"
-          label="New Password"
-          value={password}
-          style={{ width: '80%', marginTop: '15%' }}
-          onChange={(e) => setPassword(e.target.value)}
-          InputLabelProps={{
-            style: { color: '#ffffff' }
-          }}
-          InputProps={{
-            style: { color: '#ffffff' }
-          }}
-        />
-
-        <TextField
-          type={'password'}
-          required
-          variant="standard"
-          label="Confirm New Password"
-          value={confirmPassword}
-          style={{ width: '80%', marginTop: '15%' }}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          InputLabelProps={{
-            style: { color: '#ffffff' }
-          }}
-          InputProps={{
-            style: { color: '#ffffff' }
-          }}
-        />
 
         <Typography class="card-text-red">{message}</Typography>
 


### PR DESCRIPTION
enabled cross year accounts
- on every login, check if 2024 registration exists and that email is not confirmed.
- if not, create a registration object and delete resume field(should ideally add it to last registration)
- On every resume upload, change status to apply if current status is only email confirmed.