### PR TITLE
Add FAQ section and rebuild footer

### DIFF
--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -1,7 +1,85 @@
+import { IconType } from "react-icons";
+import { FaFacebookF, FaInstagram, FaLinkedinIn } from "react-icons/fa6";
+
+const SOCIAL_LINKS: { label: string; href: string; Icon: IconType }[] = [
+  {
+    label: "Facebook",
+    href: "https://www.facebook.com/HopHacks",
+    Icon: FaFacebookF,
+  },
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/company/hophacks/",
+    Icon: FaLinkedinIn,
+  },
+  {
+    label: "Instagram",
+    href: "https://www.instagram.com/hophacks/?hl=en",
+    Icon: FaInstagram,
+  },
+];
+
+const linkClass =
+  "transition-colors hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80";
+
 export default function Footer() {
   return (
-    <footer className="w-full py-6 flex items-center justify-center bg-bg-light">
-      <p className="text-sm text-text-primary">Footer!</p>
+    <footer className="w-full border-t border-white/20 bg-bg-light text-text-primary">
+      <div className="mx-auto grid w-full max-w-5xl gap-10 px-6 py-12 text-center sm:grid-cols-3 sm:text-left">
+        <div className="flex flex-col items-center gap-4 sm:items-start">
+          <span className="font-display text-3xl font-normal tracking-wide text-white">
+            HopHacks
+          </span>
+          <a
+            href="https://mlh.link/MLH-PureButtons-hackathons"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="MLH Pure Buttons"
+            className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://hophacks-website.s3.amazonaws.com/images/pure_buttons.png"
+              alt="MLH Pure Buttons"
+              className="h-auto w-24"
+            />
+          </a>
+        </div>
+
+        <div className="flex flex-col items-center gap-2 sm:items-start">
+          <a className={linkClass} href="mailto:hophacks@gmail.com">
+            hophacks@gmail.com
+          </a>
+          <span>Malone Hall</span>
+          <span>Johns Hopkins University</span>
+          <a
+            className={linkClass}
+            href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            MLH Code of Conduct
+          </a>
+        </div>
+
+        <div className="flex flex-col items-center gap-3 sm:items-start">
+          <span className="text-lg font-semibold text-white">Follow Us</span>
+          <nav aria-label="Social links" className="flex items-center gap-4">
+            {SOCIAL_LINKS.map(({ label, href, Icon }) => (
+              <a
+                key={label}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={label}
+                className="text-text-primary/90 transition hover:scale-110 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+              >
+                <Icon className="h-6 w-6" aria-hidden="true" />
+              </a>
+            ))}
+          </nav>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/frontend/app/components/faq/FaqItem.tsx
+++ b/frontend/app/components/faq/FaqItem.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { FaChevronDown } from "react-icons/fa6";
+
+import { FaqEntry } from "./faqData";
+
+interface FaqItemProps {
+  entry: FaqEntry;
+  index: number;
+}
+
+export default function FaqItem({ entry, index }: FaqItemProps) {
+  const [open, setOpen] = useState(false);
+  const panelId = `faq-panel-${index}`;
+  const buttonId = `faq-button-${index}`;
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/25 bg-white/10 transition-colors hover:bg-white/15">
+      <h3>
+        <button
+          id={buttonId}
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((value) => !value)}
+          className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left text-lg font-semibold text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 sm:text-xl"
+        >
+          <span>{entry.question}</span>
+          <FaChevronDown
+            aria-hidden="true"
+            className={`h-4 w-4 shrink-0 transition-transform duration-300 ${
+              open ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+      </h3>
+      <div
+        id={panelId}
+        role="region"
+        aria-labelledby={buttonId}
+        className={`grid transition-all duration-300 ease-in-out ${
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="px-5 pb-4 text-base leading-relaxed text-text-primary/90">
+            {entry.answer}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/faq/faqData.tsx
+++ b/frontend/app/components/faq/faqData.tsx
@@ -1,0 +1,126 @@
+import { ReactNode } from "react";
+
+export interface FaqEntry {
+  question: string;
+  answer: ReactNode;
+}
+
+const linkClass =
+  "underline underline-offset-2 transition-colors hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80";
+
+export const FAQ_ENTRIES: FaqEntry[] = [
+  {
+    question: "What is a hackathon?",
+    answer:
+      "A fast paced environment that encourages engineers, designers, and entrepreneurs to explore new ideas and create new software or hardware applications in a short timeframe. Hackers compete for prizes in tracks by sponsors, eat free food, receive cool merch, and make memories that last a lifetime!",
+  },
+  {
+    question: "What is HopHacks?",
+    answer:
+      "HopHacks is the 36 hour annual premier Hackathon held at Johns Hopkins University in the fall.",
+  },
+  {
+    question: "Who can participate?",
+    answer:
+      "Any university student enrolled in any undergraduate or graduate program may apply to hack. High school students may NOT participate. We will email you closer to the hackathon once we approve your application.",
+  },
+  {
+    question: "I don’t have a team, how can I make one?",
+    answer:
+      "We will have a team matching process after we accept hackers! You may form teams of up to four hackers, or compete solo. Additionally, we will be hosting team matching events at the start of the hackathon, so don’t worry!",
+  },
+  {
+    question: "Where will HopHacks take place?",
+    answer: (
+      <>
+        This year, HopHacks is held at Hodson Hall and the Glass Pavilion on the
+        Johns Hopkins Homewood Campus in Baltimore, MD. A campus map can be found{" "}
+        <a
+          className={linkClass}
+          href="https://drive.google.com/file/d/1aEulGqVSH3nPV2BXU90W8V-tDlFH-bRx/view?usp=sharing"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          here
+        </a>
+        , and you can navigate to us on{" "}
+        <a
+          className={linkClass}
+          href="https://www.google.com/maps/place/Hodson+Hall/@39.3275298,-76.6244881,17z"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Maps
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    question: "Is HopHacks held in-person?",
+    answer:
+      "Yes! We will be fully in-person this year so you can meet other hackers and sponsors! Unfortunately, there will be no way to attend virtually.",
+  },
+  {
+    question: "When can I pick up parking passes?",
+    answer:
+      "We will distribute parking passes to participants on the Sunday morning of HopHacks.",
+  },
+  {
+    question: "Will there be travel reimbursement?",
+    answer: (
+      <>
+        We will not be offering individual travel reimbursements. However, please
+        see the busing interest form in our{" "}
+        <a
+          className={linkClass}
+          href="https://linktr.ee/hophacks"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          LinkTree
+        </a>{" "}
+        to sign up for updates. If enough people from your city sign up, we may
+        send a FREE bus to pick up hackers in your area!
+      </>
+    ),
+  },
+  {
+    question: "What about the free food?",
+    answer:
+      "At registration, all participants will be given a wristband which MUST BE VISIBLE when you are getting food. If you do not have your wristband, you will not be able to get food.",
+  },
+  {
+    question: "Where can I find the MLH code of conduct?",
+    answer: (
+      <>
+        You can find the MLH code of conduct{" "}
+        <a
+          className={linkClass}
+          href="https://github.com/MLH/mlh-policies/blob/main/code-of-conduct.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          here.
+        </a>
+      </>
+    ),
+  },
+  {
+    question: "My question wasn’t answered here!",
+    answer: (
+      <>
+        Please email hophacks@gmail.com or ask your question in our{" "}
+        <a
+          className={linkClass}
+          href="https://discord.com/invite/8V8wmCWUhH"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Discord
+        </a>{" "}
+        and one of our organizers will get back to you soon!
+      </>
+    ),
+  },
+];

--- a/frontend/app/components/sections/FaqSection.tsx
+++ b/frontend/app/components/sections/FaqSection.tsx
@@ -1,0 +1,17 @@
+import FaqItem from "../faq/FaqItem";
+import { FAQ_ENTRIES } from "../faq/faqData";
+
+export default function FaqSection() {
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center px-6 py-20 sm:px-8">
+      <h2 className="mb-10 text-center font-display text-[clamp(2.5rem,7vw,4rem)] font-normal leading-none tracking-wide text-white/95 text-shadow-hero-title">
+        FAQ
+      </h2>
+      <div className="flex flex-col gap-3">
+        {FAQ_ENTRIES.map((entry, index) => (
+          <FaqItem key={entry.question} entry={entry} index={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import Section from "./components/Section";
 import HeroSection from "./components/sections/HeroSection";
 import AboutSection from "./components/sections/AboutSection";
 import TracksSection from "./components/sections/TracksSection";
+import FaqSection from "./components/sections/FaqSection";
 import Footer from "./components/Footer";
 
 export default function Home() {
@@ -15,6 +16,9 @@ export default function Home() {
       </Section>
       <Section id="tracks">
         <TracksSection />
+      </Section>
+      <Section id="faq">
+        <FaqSection />
       </Section>
       <Footer />
     </main>


### PR DESCRIPTION
Add an accordion FAQ section above the footer using last year's Q&A content, and replace the placeholder footer with contact, social, and MLH links styled with the new frontend's design tokens.