### PR TITLE
chore: homepage deploy prep — CTA + hide About/Tracks

### DIFF
--- a/frontend/app/components/sections/HeroSection.tsx
+++ b/frontend/app/components/sections/HeroSection.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import InterestForm from "../interest/InterestForm";
+import Link from "next/link";
 import HeroTitle from "../hero/HeroTitle";
 import SocialLinks from "../hero/SocialLinks";
 
@@ -89,7 +89,12 @@ export default function HeroSection() {
           <p className="text-base font-normal text-white/90 sm:text-lg">
             Get notified when applications open.
           </p>
-          <InterestForm compact />
+          <Link
+            href="/register/interest"
+            className="relative z-50 rounded-2xl bg-recap-gold px-6 py-3 text-base font-bold text-white shadow-[0_0_30px_rgba(255,181,31,0.35)] transition-shadow duration-300 hover:shadow-[0_0_45px_rgba(255,181,31,0.6)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+          >
+            Pre-Register
+          </Link>
         </div>
 
         <SceneLayer src={HERO_LAYERS.bluebird} alt="" priority />

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,7 @@
 import Section from "./components/Section";
 import HeroSection from "./components/sections/HeroSection";
-import AboutSection from "./components/sections/AboutSection";
-import TracksSection from "./components/sections/TracksSection";
+// import AboutSection from "./components/sections/AboutSection";
+// import TracksSection from "./components/sections/TracksSection";
 import FaqSection from "./components/sections/FaqSection";
 import Footer from "./components/Footer";
 
@@ -11,12 +11,13 @@ export default function Home() {
       <Section id="hero" borderless className="overflow-hidden p-0">
         <HeroSection />
       </Section>
-      <Section id="about">
+      {/* About and Tracks sections temporarily hidden pending content; re-enable before next milestone */}
+      {/* <Section id="about">
         <AboutSection />
       </Section>
       <Section id="tracks">
         <TracksSection />
-      </Section>
+      </Section> */}
       <Section id="faq">
         <FaqSection />
       </Section>


### PR DESCRIPTION
Per website lead, pre-deploy cleanup:

- **Removed the duplicate hero form** — the homepage hero embedded the same form as `/register/interest`. Replaced it with a "Pre-Register" CTA button linking to that page (keeps the homepage conversion path; single source of truth for the form).
- **Commented out the About and Tracks sections** in `app/page.tsx` (content not finalized) so they can be re-enabled later. Homepage is now Hero → FAQ → Footer.

Verified: `next build` green, Prettier clean, browser-checked (hero shows CTA, no form; About/Tracks gone).