### PR TITLE
fix: point Zappa app_function at wsgi.app (completes #464)

### DIFF
--- a/api/src/zappa_settings.json
+++ b/api/src/zappa_settings.json
@@ -1,6 +1,6 @@
 {
   "production": {
-    "app_function": "handler.app",
+    "app_function": "wsgi.app",
     "aws_region": "us-east-1",
     "s3_bucket": "hophacks-zappa-deployments",
     "project_name": "hophacks-api",


### PR DESCRIPTION
## Why
PR #464 renamed `handler.py` → `wsgi.py` but, due to a staging slip, **did not include the config change** — `zappa_settings.json` still had `"app_function": "handler.app"`. Now that our `handler.py` is gone, that points at nothing, so prod still returns 500 `'NoneType' object is not callable` and the deploy health check still 502s.

Confirmed prod is still down after #464 merged: `GET /api/interest/count` → 500.

## Fix
One line: `app_function: "handler.app"` → `"wsgi.app"`, so Zappa loads the real Flask app from `wsgi.py`.

Verified locally that booting via `wsgi.app` serves 200s. This completes the fix from #464 — once merged and deployed, `GET /` should return a normal 404 (not 502), the deploy Action should go green, and the API/form should work.