### PR TITLE
fix: load config by absolute path so the app boots on Lambda

### DIFF
--- a/api/src/wsgi.py
+++ b/api/src/wsgi.py
@@ -1,3 +1,10 @@
+import os
+
 from app import create_app
 
-app = create_app()
+# Anchor the config path to this file, not the process working directory.
+# On Lambda the cwd is not api/src, so create_app()'s default relative
+# 'config/config.json' would fail to load and leave the app uninitialized.
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config", "config.json")
+
+app = create_app(CONFIG_PATH)


### PR DESCRIPTION
## Why it's *still* 500ing after #464 + #465
Those two fixed the handler-name collision and the `app_function` pointer — necessary, but not sufficient. Prod still returns the same `'NoneType' object is not callable`, because now `create_app()` itself throws at cold start.

Root cause (reproduced locally): `create_app()` loads config via the **relative** path `config/config.json`, which only resolves when the working directory is `api/src`. On Lambda the cwd isn't `api/src`, so the load raises `FileNotFoundError`, `wsgi.py` fails to import, and `wsgi.app` is never defined → Zappa's `app_function` resolves to `None` → every request 500s.

My earlier "works locally" check was invalid — I happened to run it from `api/src`. Importing `wsgi` from `cwd=/tmp` reproduces the exact prod failure.

## Fix
Anchor the config path to `wsgi.py`'s own directory instead of the cwd:
```python
CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config", "config.json")
app = create_app(CONFIG_PATH)
```

Verified: `import wsgi` now loads a real Flask app from `cwd=/tmp` and `cwd=/` (both previously failed). On Lambda `__file__` is `/var/task/wsgi.py`, so config resolves to `/var/task/config/config.json`, which is what the deploy packages.

After deploy, `GET /` should return 404 (not 502), the deploy health check should pass, and the API/form should work. If a *new* error appears (e.g. a MongoDB timeout), that'd be the next layer — Lambda→Atlas reachability — and I'll check it immediately.