### PR TITLE
fix: add dnspython for Atlas mongodb+srv URI

### DIFF
--- a/api/requirements-2026.txt
+++ b/api/requirements-2026.txt
@@ -10,6 +10,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 discord-webhook==0.16.3
+dnspython==2.1.0
 docutils==0.15.2
 Flask==1.1.2
 Flask-Cors==4.0.0


### PR DESCRIPTION
Next layer surfaced by the diagnostic: `create_app()` failed at `db.init_app` → `pymongo ... ConfigurationError: The "dnspython" module must be installed to use mongodb+srv:// URIs`. The prod `MONGO_URI` is an Atlas SRV string; pymongo needs `dnspython` to resolve it, and it wasn't in requirements. Verified locally that pymongo 3.11.2 + dnspython 2.1.0 parses srv URIs correctly. Never reproduced before because local config uses a plain `mongodb://localhost` URI.