### PR TITLE
fix(ci): gate mail config on full credential set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,9 @@ jobs:
               'MONGO_DB_NAME': os.environ['MONGO_DB_NAME'],
               'BASE_URL': os.environ['BASE_URL'],
           }
-          if os.environ.get('MAIL_SERVER'):
+          # Require the full credential set; a half-configured mailer (e.g.
+          # server set but password pending) must stay suppressed, not 500.
+          if os.environ.get('MAIL_SERVER') and os.environ.get('MAIL_PASSWORD'):
               config['MAIL_SERVER'] = os.environ['MAIL_SERVER']
               config['MAIL_PORT'] = int(os.environ['MAIL_PORT'])
               config['MAIL_USERNAME'] = os.environ['MAIL_USERNAME']

--- a/frontend/app/profile/useProfile.ts
+++ b/frontend/app/profile/useProfile.ts
@@ -21,7 +21,9 @@ export type SaveState = "idle" | "saving" | "saved" | "error";
 export function useProfile() {
   const [rawProfile, setRawProfile] = useState<Record<string, unknown>>({});
   const [values, setValues] = useState<ProfileFormValues | null>(null);
-  const [savedValues, setSavedValues] = useState<ProfileFormValues | null>(null);
+  const [savedValues, setSavedValues] = useState<ProfileFormValues | null>(
+    null,
+  );
   const [loadError, setLoadError] = useState(false);
   const [errors, setErrors] = useState<ProfileFormErrors>({});
   const [saveState, setSaveState] = useState<SaveState>("idle");

--- a/frontend/app/register/signup/page.tsx
+++ b/frontend/app/register/signup/page.tsx
@@ -513,8 +513,8 @@ function StepChecks({
       <div className="flex flex-col gap-5">
         <SectionTitle>Application questions</SectionTitle>
         <p className="-mt-2 text-sm text-white/75">
-          Both questions are required. Responses are capped at {ESSAY_WORD_LIMIT}{" "}
-          words each.
+          Both questions are required. Responses are capped at{" "}
+          {ESSAY_WORD_LIMIT} words each.
         </p>
         <Field label="Share a project, technical or not, that you're genuinely proud of. What was the hardest decision you made, and why did you make it that way?">
           <>
@@ -1107,9 +1107,7 @@ export default function SignUpPage() {
       return;
     }
     if (wordCount(essayProject) > ESSAY_WORD_LIMIT) {
-      setErrorMsg(
-        `* First answer must be ${ESSAY_WORD_LIMIT} words or fewer.`,
-      );
+      setErrorMsg(`* First answer must be ${ESSAY_WORD_LIMIT} words or fewer.`);
       return;
     }
     if (!essayTeam.trim()) {


### PR DESCRIPTION
Mail secrets are being added incrementally (server/port/username are in; the mailbox password is pending from GoDaddy). Until now a deploy in that window would write a half-configured mailer into the Lambda config and every registration would 500 at confirmation-send time. Mail now stays suppressed unless both MAIL_SERVER and MAIL_PASSWORD exist.
