### PR TITLE
hotfix: prod /api 404s — default the rewrite to the live Lambda

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,17 +7,19 @@ const nextConfig: NextConfig = {
   //
   // - Dev: proxies to the local Flask server (the docker dev API listens on
   //   :5001). Leave NEXT_PUBLIC_BACKENDURL unset in .env.local.
-  // - Prod (Vercel): set BACKEND_ORIGIN to the backend base URL *including
-  //   any stage prefix*, e.g.
-  //   https://btl4e6jswl.execute-api.us-east-1.amazonaws.com/production
-  //   and REMOVE NEXT_PUBLIC_BACKENDURL so axios uses same-origin paths.
-  //   As a safety net, production builds ignore NEXT_PUBLIC_BACKENDURL
-  //   entirely (see configureAxios in app/util/auth.tsx).
+  // - Prod (Vercel): BACKEND_ORIGIN overrides the backend base URL
+  //   (including any stage prefix). When unset, production builds fall back
+  //   to the live Lambda stage below — an unset env var must degrade to the
+  //   working backend, not to rewrites:[] (which 404s every /api call on
+  //   the deployed site). Production builds also ignore
+  //   NEXT_PUBLIC_BACKENDURL entirely (see configureAxios in
+  //   app/util/auth.tsx).
   async rewrites() {
     const target =
       process.env.BACKEND_ORIGIN ??
-      (process.env.NODE_ENV === "development" ? "http://127.0.0.1:5001" : null);
-    if (!target) return [];
+      (process.env.NODE_ENV === "development"
+        ? "http://127.0.0.1:5001"
+        : "https://btl4e6jswl.execute-api.us-east-1.amazonaws.com/production");
     return [
       {
         source: "/api/:path*",


### PR DESCRIPTION
Prod outage: #476 switched the frontend to a same-origin /api proxy that requires the BACKEND_ORIGIN env var in Vercel, which was never set. rewrites() returned [] and every /api call on hophacks.com 404s (signup + login down, confirmed by clicking Finish on prod).

Fix: production builds fall back to the live Lambda stage URL when BACKEND_ORIGIN is unset. The env var still overrides when someone sets it.

Verified: prettier, tsc, next build green. Merge deploys the fix.