### PR TITLE
hotfix: registrations 500 — empty MAIL_DEFAULT_SENDER from unset secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,10 +49,12 @@ jobs:
               config['MAIL_PORT'] = int(os.environ['MAIL_PORT'])
               config['MAIL_USERNAME'] = os.environ['MAIL_USERNAME']
               config['MAIL_PASSWORD'] = os.environ['MAIL_PASSWORD']
-              config['MAIL_DEFAULT_SENDER'] = os.environ.get('MAIL_DEFAULT_SENDER', 'team@hophacks.com')
-              use_tls = os.environ.get('MAIL_USE_TLS', 'true').lower()
-              config['MAIL_USE_TLS'] = use_tls not in ('false', '0', '')
-              use_ssl = os.environ.get('MAIL_USE_SSL', 'false').lower()
+              # 'or' (not get-default): unset secrets reach here as empty
+              # strings, and an empty sender/flag must fall back, not pass.
+              config['MAIL_DEFAULT_SENDER'] = os.environ.get('MAIL_DEFAULT_SENDER') or 'team@hophacks.com'
+              use_tls = (os.environ.get('MAIL_USE_TLS') or 'true').lower()
+              config['MAIL_USE_TLS'] = use_tls not in ('false', '0')
+              use_ssl = (os.environ.get('MAIL_USE_SSL') or 'false').lower()
               config['MAIL_USE_SSL'] = use_ssl in ('true', '1')
           if os.environ.get('CORS_ORIGINS'):
               config['CORS_ORIGINS'] = os.environ['CORS_ORIGINS']

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -83,7 +83,9 @@ def create_app(config_file='config/config.json'):
 
     # All outbound mail relies on this default sender (Message calls do not
     # pass sender= explicitly, so the configured value actually takes effect).
-    if ('MAIL_DEFAULT_SENDER' not in app.config):
+    # Guard against present-but-empty too: deploy writes '' when the secret
+    # is unset, and flask-mail asserts on a falsy sender at send time.
+    if (not app.config.get('MAIL_DEFAULT_SENDER')):
         app.config['MAIL_DEFAULT_SENDER'] = 'team@hophacks.com'
 
     app.config['SLACK_SUPPRESS_SEND'] = False

--- a/api/test/test_app_config.py
+++ b/api/test/test_app_config.py
@@ -1,0 +1,27 @@
+import json
+import sys
+
+sys.path.append('../src')
+
+from app import create_app
+
+
+def _make_config(tmp_path, extra):
+    base = json.load(open('test.json'))
+    base.update(extra)
+    path = tmp_path / 'config.json'
+    path.write_text(json.dumps(base))
+    return str(path)
+
+
+def test_empty_mail_default_sender_falls_back(tmp_path):
+    """Deploy writes MAIL_DEFAULT_SENDER='' when the secret is unset; a falsy
+    sender must fall back, or flask-mail asserts at send time and every
+    registration 500s (broke prod 2026-07-19)."""
+    app = create_app(_make_config(tmp_path, {'MAIL_DEFAULT_SENDER': ''}))
+    assert app.config['MAIL_DEFAULT_SENDER'] == 'team@hophacks.com'
+
+
+def test_explicit_mail_default_sender_wins(tmp_path):
+    app = create_app(_make_config(tmp_path, {'MAIL_DEFAULT_SENDER': 'x@y.z'}))
+    assert app.config['MAIL_DEFAULT_SENDER'] == 'x@y.z'


### PR DESCRIPTION
Second prod issue from the #476 rollout: the MAIL_DEFAULT_SENDER secret was never created, GH Actions exports unset secrets as empty strings, and both the deploy config-writer and app.py treated present-but-empty as configured. flask-mail asserts on a falsy sender inside mail.send, so every /api/accounts/create 500'd after the sender was moved from per-message args to config.

Fix: falsy values fall back to team@hophacks.com at both layers, same hardening for the MAIL_USE_TLS/SSL flags, plus a regression test (70 backend tests green).

Merge deploys the fix (Lambda side).