### PR TITLE
hotfix: resume upload 308s through the Vercel proxy (trailing slash)

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -30,6 +30,13 @@ def get_req_config(app, config, key):
 def create_app(config_file='config/config.json'):
     app = Flask(__name__)
 
+    # The Vercel /api proxy may deliver slash-terminated routes with or
+    # without the trailing slash (Next's :path* rewrite does not preserve
+    # it reliably). Accept both instead of 308-redirecting, because a
+    # redirect through API Gateway loses the stage prefix and breaks the
+    # client (prod resume upload broke this way).
+    app.url_map.strict_slashes = False
+
     # Every email template shows the event name/dates; expose them as Jinja
     # globals so render_template callers never have to thread them through.
     app.jinja_env.globals.update(event_name=EVENT_NAME, event_dates=EVENT_DATES)

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Some Flask endpoints are slash-terminated (/api/resumes/, /api/admin/).
+  // Without this, Next 308-redirects them to the slashless form BEFORE the
+  // /api rewrite runs, and the redirect chain through API Gateway drops the
+  // stage prefix — resume upload/download broke in prod this way. Flask
+  // accepts both forms (strict_slashes disabled in create_app).
+  skipTrailingSlashRedirect: true,
   // Same-origin /api proxy so the HttpOnly refresh-token cookie is always
   // first-party (cross-site cookies to the raw API Gateway URL are dropped
   // by browsers, which kills session refresh — the prod login loop).


### PR DESCRIPTION
Third rollout issue: slash-terminated Flask routes (/api/resumes/, /api/admin/) get 308-redirected by Next before the /api rewrite applies, and the redirect chain through API Gateway drops the stage prefix. Resume upload/download and the admin check fail via hophacks.com while working direct-to-Lambda (verified both ways with a live smoke account).

Fix: skipTrailingSlashRedirect in next.config + strict_slashes=False in Flask, so both URL forms resolve with zero redirect hops in every environment.

Gates: 70 backend tests, tsc, prettier, build green. Merge deploys both halves.