### PR TITLE
Admin-only account deletion (cleanup for test registrations)

### DIFF
--- a/api/src/admin.py
+++ b/api/src/admin.py
@@ -8,6 +8,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from bson import ObjectId
 
 import boto3
+import botocore.exceptions
 import csv
 import io
 from werkzeug.utils import secure_filename
@@ -61,6 +62,51 @@ def promote_admin():
 
     db.users.update_one({'_id': user['_id']}, {'$set': {'is_admin': True}})
     return jsonify({'msg': '{} is now an admin'.format(user['username'])}), 200
+
+
+@admin_api.route('/users', methods=['DELETE'])
+@jwt_required
+@check_admin
+def delete_user():
+    """Permanently delete an account and its S3 resume (admin-only).
+
+    Intended for test/junk registrations. Admin accounts cannot be deleted
+    through this endpoint (demote first, in the database, if ever needed).
+
+    :reqjson username: email of the account to delete
+
+    :status 200: Deleted
+    :status 400: Missing username, or target is an admin
+    :status 404: No account with that email
+    """
+    from accounts import username_filter
+    from resumes import BUCKET
+
+    username = request.json.get('username') if request.json else None
+    if (not isinstance(username, str) or not username.strip()):
+        return jsonify({'msg': 'Missing username'}), 400
+
+    user = db.users.find_one(username_filter(username.strip()))
+    if (user is None):
+        return jsonify({'msg': 'No account with that email'}), 404
+
+    if (user.get('is_admin')):
+        return jsonify({'msg': 'Refusing to delete an admin account'}), 400
+
+    if (user.get('resume')):
+        s3 = boto3.client('s3')
+        key = '{}/{}-{}'.format(EVENT_SLUG, str(user['_id']), user['resume'])
+        try:
+            s3.delete_object(Bucket=BUCKET, Key=key)
+        except botocore.exceptions.BotoCoreError:
+            # The account row is the thing that must go; an orphaned S3
+            # object is acceptable and cleanable later.
+            pass
+        except botocore.exceptions.ClientError:
+            pass
+
+    db.users.delete_one({'_id': user['_id']})
+    return jsonify({'msg': '{} deleted'.format(user['username'])}), 200
 
 @admin_api.route('/users', methods=['GET'])
 @jwt_required

--- a/api/test/test_admin_delete.py
+++ b/api/test/test_admin_delete.py
@@ -1,0 +1,40 @@
+import sys
+sys.path.append('../src')
+
+from utils import create_json, login_json
+from flow import register_confirmed, admin_token, bearer
+
+
+def test_delete_user(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+
+    res = client.delete('/api/admin/users', json={'username': 'A@TEST.com'},
+                        headers=bearer(admin))
+    assert res.status_code == 200
+    assert test_db.users.find_one({'username': 'a@test.com'}) is None
+
+
+def test_delete_unknown_email_404(client, test_db, test_mail):
+    admin = admin_token(client, test_db)
+    res = client.delete('/api/admin/users', json={'username': 'ghost@test.com'},
+                        headers=bearer(admin))
+    assert res.status_code == 404
+
+
+def test_delete_refuses_admin_target(client, test_db, test_mail):
+    admin = admin_token(client, test_db)
+    res = client.delete('/api/admin/users', json={'username': 'admin'},
+                        headers=bearer(admin))
+    assert res.status_code == 400
+    assert test_db.users.find_one({'username': 'admin'}) is not None
+
+
+def test_delete_requires_admin(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    res = client.post('/api/auth/login', json=login_json)
+    token = res.json['access_token']
+    res = client.delete('/api/admin/users', json={'username': 'a@test.com'},
+                        headers=bearer(token))
+    assert res.status_code == 401
+    assert test_db.users.find_one({'username': 'a@test.com'}) is not None

--- a/frontend/app/admin/panels/Applications.tsx
+++ b/frontend/app/admin/panels/Applications.tsx
@@ -9,6 +9,7 @@ import {
   waitlist,
   reject,
   checkIn,
+  deleteUser,
   openResume,
   downloadCsv,
   getUsers,
@@ -304,6 +305,22 @@ export default function ApplicationsPage() {
                           Resume
                         </button>
                       ) : null}
+                      <button
+                        disabled={isBusy}
+                        className="rounded border border-red-300 px-2 py-1 text-red-600 hover:bg-red-50 disabled:opacity-50"
+                        onClick={() => {
+                          if (
+                            window.confirm(
+                              `Permanently delete ${u.username}? This removes the account and resume; it cannot be undone.`,
+                            )
+                          )
+                            run("Deleted.", () => deleteUser(u.username), [
+                              u.id,
+                            ]);
+                        }}
+                      >
+                        Delete
+                      </button>
                     </div>
                   </td>
                 </tr>

--- a/frontend/app/util/adminApi.ts
+++ b/frontend/app/util/adminApi.ts
@@ -67,6 +67,10 @@ export async function getStats(): Promise<AdminStats> {
   return r.data;
 }
 
+/** Permanently delete a non-admin account (test/junk registrations). */
+export const deleteUser = (username: string) =>
+  axios.delete("/api/admin/users", { data: { username } });
+
 export async function getAdmins(): Promise<string[]> {
   const r = await axios.get("/api/admin/admins");
   return r.data.admins ?? [];


### PR DESCRIPTION
Adds DELETE /api/admin/users (admin-only): looks up the account case-insensitively, refuses admin targets, deletes the S3 resume when present (tolerating S3 failures; the DB row is what must go), then removes the user. The Applications tab gets a confirm-guarded Delete button per row.

Motivation: prod has accumulated test registrations (chunkymonkeydumpy, smoke-resume-478@example.com) with no removal path short of direct Atlas access.

78 backend tests (4 new: delete/404/refuses-admin/authz), tsc, prettier, build green.