### PR TITLE
feat: harden accept/reject/waitlist pipeline for acceptance day

### DIFF
--- a/api/src/admin.py
+++ b/api/src/admin.py
@@ -200,7 +200,7 @@ def get_all_users_account():
     users = []
     
     for document in cursor:
-        if not document['is_admin']:
+        if not document.get('is_admin'):
             users.append({'id': str(document['_id']), 'username': str(document['username']), 'profile': document['profile'], 'email_confirmed': document['email_confirmed'], 'registrations': document['registrations'], 'resume': document.get("resume"), 'vaccination': document.get("vaccination"), 'apply_at': document.get('apply_at')})
         
 

--- a/api/src/registrations.py
+++ b/api/src/registrations.py
@@ -54,38 +54,74 @@ def send_rsvp_info(users):
             msg.html = render_template('rsvpinfo.html', first_name=user['profile']['first_name'])
             conn.send(msg)
 
-def send_acceptances(users):
-     with mail.connect() as conn:
-        for user in users:
-            email = user["username"]
-            subject = "Acceptance Letter - Hophacks.com"
-            msg = Message(recipients=[email],
-                          subject=subject)
+def _send_decision_emails(users, subject, body, template):
+    """Email each user; one SMTP failure must not abort the rest of the batch.
 
-            msg.body = 'Congrats on being accepted to HopHacks!'
-            msg.html = render_template('email_acceptance.html', first_name=user['profile']['first_name'])
-            conn.send(msg)
-
-def send_rejections(user):
+    Returns the number of failed sends so endpoints can surface it.
+    """
+    failures = 0
     with mail.connect() as conn:
-        email = user["username"]
-        subject = "Status Update - HopHacks.com"
-        msg = Message(recipients=[email],
-                        subject=subject)
-        msg.body = "Thanks for applying, unfortunately we weren't able to accept you into HopHacks."
-        msg.html = render_template('email_rejection.html', first_name=user['profile']['first_name'])
-        conn.send(msg)
+        for user in users:
+            try:
+                msg = Message(recipients=[user["username"]],
+                              subject=subject)
+                msg.body = body
+                msg.html = render_template(template, first_name=user['profile']['first_name'])
+                conn.send(msg)
+            except Exception:
+                failures += 1
+    return failures
+
+def send_acceptances(users):
+    return _send_decision_emails(
+        users,
+        "Acceptance Letter - Hophacks.com",
+        'Congrats on being accepted to HopHacks!',
+        'email_acceptance.html')
+
+def send_rejections(users):
+    return _send_decision_emails(
+        users,
+        "Status Update - HopHacks.com",
+        "Thanks for applying, unfortunately we weren't able to accept you into HopHacks.",
+        'email_rejection.html')
 
 def send_waitlist(users):
-    with mail.connect() as conn:
-        for user in users:
-            email = user["username"]
-            subject = "Waitlist Update - HopHacks.com"
-            msg = Message(recipients=[email],
-                          subject=subject)
-            msg.body = "You've been placed on the HopHacks waitlist. We'll reach out if a spot opens up."
-            msg.html = render_template('email_waitlist.html', first_name=user['profile']['first_name'])
-            conn.send(msg)
+    return _send_decision_emails(
+        users,
+        "Waitlist Update - HopHacks.com",
+        "You've been placed on the HopHacks waitlist. We'll reach out if a spot opens up.",
+        'email_waitlist.html')
+
+def apply_decision(ids, event, guard_statuses, set_fields, unset_fields=None):
+    """Transition each user's <event> registration unless its status is in
+    guard_statuses. The guard lives inside the atomic filter, so a repeat
+    request can never re-transition (or re-email) a user. $nin treats a
+    missing status field as eligible, which keeps legacy docs decidable.
+
+    Returns (changed_users, skipped_ids); changed docs are pre-update.
+    """
+    update = {'$set': set_fields}
+    if unset_fields:
+        update['$unset'] = unset_fields
+
+    changed, skipped = [], []
+    for raw_id in ids:
+        doc = db.users.find_one_and_update(
+            {
+                '_id': ObjectId(raw_id),
+                'registrations': {'$elemMatch': {
+                    'event': event,
+                    'status': {'$nin': guard_statuses}
+                }}
+            },
+            update
+        )
+        if doc is None:
+            skipped.append(raw_id)
+        else:
+            changed.append(doc)
+    return changed, skipped
 
 def send_apply_confirm(email, name):
     msg = Message("Received Application - HopHacks.com",
@@ -202,32 +238,21 @@ def accept():
         return Response('Invalid request', status=400)
 
     event = request.json.get("event", EVENT_NAME)
-    ids = [ObjectId(id) for id in request.json["users"]]
 
-    result = db.users.update_many(
+    changed, skipped = apply_decision(
+        request.json["users"], event,
+        ["accepted", "rsvped", "checked_in"],
         {
-            '_id': {'$in': ids},
-            'registrations.event' : event
-        },
-        {
-            '$set': {
-                "registrations.$.accept": True,
-                "registrations.$.accept_at": datetime.datetime.utcnow(),
-                "registrations.$.status": "accepted"
-            }
+            "registrations.$.accept": True,
+            "registrations.$.accept_at": datetime.datetime.utcnow(),
+            "registrations.$.status": "accepted"
         }
     )
 
-    users = db.users.find(
-        {
-            '_id': {'$in': ids},
-            'registrations.event' : event
-        }
-    )
+    failures = send_acceptances(changed)
 
-    send_acceptances(users)
-
-    return jsonify({"num_changed": result.modified_count}), 200
+    return jsonify({"num_changed": len(changed), "skipped": skipped,
+                    "email_failures": failures}), 200
 
 
 @registrations_api.route('/check_in', methods = ['POST'])
@@ -276,46 +301,52 @@ def check_in():
 @jwt_required
 @check_admin
 def reject():
-    """As an admin user,reject user in to an event
+    """As an admin, reject a list of users for an event and email them.
+
+    Also clears the accept flag so a previously accepted user cannot RSVP.
 
     :reqheader Authorization: ``Bearer <JWT Token>``, needs to be admin account
 
-    :reqjson user: User id to be reject
-    :reqjson event: Semester and year, for exmaple ``Spring_2020``
+    :reqjson users: List of user ids to mark as rejected
+    :reqjson user: Single user id (legacy alternative to ``users``)
+    :reqjson event: Event name (defaults to the current event)
 
     .. sourcecode:: json
 
         {
-            "user": "XuiJJ8rJRrbNJZ3Nb",
+            "users": ["XuiJJ8rJRrbNJZ3Nb", "GF42GBb238BGO"],
             "event": "Spring_2020"
         }
 
     :status 200: Successful
+    :status 400: Invalid request
     :status 401: Not logged in as admin
     :status 422: Not logged in
 
     """
-    event = request.json.get("event", EVENT_NAME)
-    user_id = request.json["user"]
+    if ('users' in request.json):
+        ids = request.json['users']
+    elif ('user' in request.json):
+        ids = [request.json['user']]
+    else:
+        return Response('Invalid request', status=400)
 
-    result = db.users.update_one(
+    event = request.json.get("event", EVENT_NAME)
+
+    changed, skipped = apply_decision(
+        ids, event,
+        ["rejected", "rsvped", "checked_in"],
         {
-            '_id': ObjectId(user_id),
-            'registrations.event' : event
-        },
-        {
-            '$set': {
-                "registrations.$.reject_at": datetime.datetime.utcnow(),
-                "registrations.$.status": "rejected"
-            }
+            "registrations.$.accept": False,
+            "registrations.$.reject_at": datetime.datetime.utcnow(),
+            "registrations.$.status": "rejected"
         }
     )
 
-    user = db.users.find_one({'_id': ObjectId(user_id)})
-    if user:
-        send_rejections(user)
+    failures = send_rejections(changed)
 
-    return jsonify({"num_changed": result.modified_count}), 200
+    return jsonify({"num_changed": len(changed), "skipped": skipped,
+                    "email_failures": failures}), 200
 
 
 @registrations_api.route('/waitlist', methods = ['POST'])
@@ -339,32 +370,70 @@ def waitlist():
         return Response('Invalid request', status=400)
 
     event = request.json.get("event", EVENT_NAME)
-    ids = [ObjectId(id) for id in request.json["users"]]
 
-    result = db.users.update_many(
+    changed, skipped = apply_decision(
+        request.json["users"], event,
+        ["waitlisted", "rsvped", "checked_in"],
         {
-            '_id': {'$in': ids},
-            'registrations.event': event
+            "registrations.$.status": "waitlisted",
+            "registrations.$.waitlist_at": datetime.datetime.utcnow(),
+            "registrations.$.accept": False
+        }
+    )
+
+    failures = send_waitlist(changed)
+
+    return jsonify({"num_changed": len(changed), "skipped": skipped,
+                    "email_failures": failures}), 200
+
+
+@registrations_api.route('/revert', methods = ['POST'])
+@jwt_required
+@check_admin
+def revert():
+    """As an admin, silently reset users' registrations to "applied".
+
+    Recovery path for a misclicked decision: restores the fresh-registration
+    shape (accounts.confirm_email) and sends no email. This is also the only
+    way out of the rsvped / checked_in statuses, which the decision endpoints
+    refuse to touch.
+
+    :reqheader Authorization: ``Bearer <JWT Token>``, needs to be admin account
+
+    :reqjson users: List of user ids to reset
+    :reqjson event: Event name (defaults to the current event)
+
+    :status 200: Successful
+    :status 400: Invalid request
+    :status 401: Not logged in as admin
+    :status 422: Not logged in
+
+    """
+    if ('users' not in request.json):
+        return Response('Invalid request', status=400)
+
+    event = request.json.get("event", EVENT_NAME)
+
+    changed, skipped = apply_decision(
+        request.json["users"], event,
+        ["applied"],
+        {
+            "registrations.$.accept": False,
+            "registrations.$.rsvp": False,
+            "registrations.$.checkin": False,
+            "registrations.$.status": "applied"
         },
         {
-            '$set': {
-                "registrations.$.status": "waitlisted",
-                "registrations.$.waitlist_at": datetime.datetime.utcnow(),
-                "registrations.$.accept": False
-            }
+            "registrations.$.accept_at": "",
+            "registrations.$.waitlist_at": "",
+            "registrations.$.reject_at": "",
+            "registrations.$.rsvp_time": "",
+            "registrations.$.checkin_at": ""
         }
     )
 
-    users = db.users.find(
-        {
-            '_id': {'$in': ids},
-            'registrations.event': event
-        }
-    )
-
-    send_waitlist(users)
-
-    return jsonify({"num_changed": result.modified_count}), 200
+    return jsonify({"num_changed": len(changed), "skipped": skipped,
+                    "email_failures": 0}), 200
 
 
 @registrations_api.route('/rsvp/view', methods = ['GET'])
@@ -412,7 +481,11 @@ def rsvp_status():
     id = get_jwt_identity()
     user = db.users.find_one({'_id' : ObjectId(id)})
 
-    eventInfo = user["registrations"][0] # only need to check first one, because there should only be one entry
+    regs = user.get("registrations") or []
+    if (len(regs) == 0):
+        return jsonify({"status": False}), 200
+
+    eventInfo = regs[0] # only need to check first one, because there should only be one entry
     if("rsvp" not in eventInfo or eventInfo["rsvp"] == False):
         return jsonify({"status":False}),200 
     elif(eventInfo["rsvp"] == True):

--- a/api/src/templates/email_waitlist.html
+++ b/api/src/templates/email_waitlist.html
@@ -1,89 +1,309 @@
-<!DOCTYPE html>
-<html lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light only" />
+    <meta name="supported-color-schemes" content="light" />
     <title>HopHacks Waitlist Update</title>
+    <style type="text/css">
+      /* Reset styles */
+      body,
+      table,
+      td,
+      p,
+      a,
+      li,
+      blockquote {
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+      table,
+      td {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+      img {
+        -ms-interpolation-mode: bicubic;
+        border: 0;
+        outline: none;
+        text-decoration: none;
+      }
+
+      /* Outlook fixes */
+      table {
+        border-collapse: collapse !important;
+      }
+      .ReadMsgBody {
+        width: 100%;
+      }
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+
+      /* Background image approach to prevent dark mode override */
+      .bg-light-blue {
+        background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTZmMGY2Ii8+PC9zdmc+") !important;
+        background-color: #e6f0f6; /* Fallback */
+      }
+
+      .bg-white {
+        background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZmZmZmZmIi8+PC9zdmc+") !important;
+        background-color: #ffffff; /* Fallback */
+      }
+
+      .text-dark {
+        color: #333333 !important;
+      }
+
+      .text-muted {
+        color: #666666 !important;
+      }
+
+      .border-light-gray {
+        border-color: #cccccc !important;
+      }
+
+      /* Mobile styles */
+      @media only screen and (max-width: 600px) {
+        .container {
+          width: 100% !important;
+          max-width: 600px !important;
+        }
+        .mobile-center {
+          text-align: center !important;
+        }
+        .mobile-padding {
+          padding: 20px !important;
+        }
+        .mobile-font-size {
+          font-size: 24px !important;
+        }
+      }
+    </style>
   </head>
-  <body style="margin: 0; padding: 0; background-color: #f4f4f4;">
+  <body style="margin: 0; padding: 0" class="bg-light-blue">
+    <!-- Wrapper table -->
     <table
-      role="presentation"
-      width="100%"
+      border="0"
       cellpadding="0"
       cellspacing="0"
-      style="background-color: #f4f4f4; padding: 30px 0;"
+      width="100%"
+      class="bg-light-blue"
     >
       <tr>
         <td align="center">
+          <!-- Main container -->
           <table
-            role="presentation"
-            width="600"
+            border="0"
             cellpadding="0"
             cellspacing="0"
-            style="
-              background-color: #ffffff;
-              border-radius: 8px;
-              overflow: hidden;
-              max-width: 600px;
-              width: 100%;
-            "
+            width="590"
+            class="container bg-white"
+            style="margin: 20px auto"
           >
+            <!-- Header with logo -->
             <tr>
-              <td style="padding: 40px 40px 20px 40px;">
-                <h2
+              <td
+                align="center"
+                style="padding: 20px 20px 40px 20px"
+                class="bg-light-blue"
+              >
+                <img
+                  src="https://hophacks.com/images/hophacks-logo.png"
+                  alt="HopHacks Logo"
+                  width="150"
+                  style="display: block; max-width: 100%; height: auto"
+                />
+                <p
                   style="
-                    margin: 0 0 15px 0;
-                    font-family: 'Times New Roman', Times, serif;
-                    font-size: 28px;
-                    font-weight: normal;
+                    margin: 18px 0 0 0;
+                    font-family: Arial, Helvetica, sans-serif;
+                    font-size: 24px;
+                    font-weight: bold;
+                    color: #001d4c;
+                  "
+                >
+                  HopHacks {{ event_name }}
+                </p>
+                <p
+                  style="
+                    margin: 6px 0 0 0;
+                    font-family: Arial, Helvetica, sans-serif;
+                    font-size: 15px;
                     color: #333333;
-                    line-height: 34px;
                   "
                 >
-                  Hi {{first_name}},
-                </h2>
-
-                <p
-                  style="
-                    margin: 0 0 20px 0;
-                    font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-                    font-size: 16px;
-                    line-height: 24px;
-                    color: #666666;
-                  "
-                >
-                  Thank you for registering for HopHacks {{ event_name }}! Because of the
-                  high number of applications, we've placed you on our
-                  <strong>waitlist</strong> for now.
+                  {{ event_dates }} &middot; Johns Hopkins University
                 </p>
+              </td>
+            </tr>
 
-                <p
-                  style="
-                    margin: 0 0 20px 0;
-                    font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-                    font-size: 16px;
-                    line-height: 24px;
-                    color: #666666;
-                  "
-                >
-                  Spots often open up as accepted hackers finalize their plans. If
-                  one becomes available, we'll email you right away with next steps,
-                  so keep an eye on your inbox. No action is needed from you at this
-                  time.
-                </p>
+            <!-- Main content -->
+            <tr>
+              <td
+                style="padding: 30px 40px 20px 40px"
+                class="mobile-padding bg-white"
+              >
+                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td>
+                      <!-- Greeting -->
+                      <h2
+                        style="
+                          margin: 0 0 15px 0;
+                          font-family: 'Times New Roman', Times, serif;
+                          font-size: 28px;
+                          font-weight: normal;
+                          color: #333333;
+                          line-height: 34px;
+                        "
+                        class="mobile-font-size mobile-center text-dark"
+                      >
+                        Hi {{first_name}},
+                      </h2>
 
-                <p
-                  style="
-                    margin: 0;
-                    font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-                    font-size: 16px;
-                    line-height: 24px;
-                    color: #666666;
-                  "
-                >
-                  Thanks for your patience and interest in HopHacks!<br />
-                  &mdash; The HopHacks Team
-                </p>
+                      <!-- Message -->
+                      <p
+                        style="
+                          margin: 0 0 20px 0;
+                          font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+                          font-size: 16px;
+                          line-height: 24px;
+                          color: #666666;
+                        "
+                        class="text-muted"
+                      >
+                        Thank you for registering for HopHacks {{ event_name }}! Because of the high number of applications, we've placed you on our <strong>waitlist</strong> for now.
+                      </p>
+
+                      <p
+                        style="
+                          margin: 0 0 20px 0;
+                          font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+                          font-size: 16px;
+                          line-height: 24px;
+                          color: #666666;
+                        "
+                        class="text-muted"
+                      >
+                        Spots often open up as accepted hackers finalize their plans. If one becomes available, we'll email you right away with next steps, so keep an eye on your inbox. No action is needed from you at this time.
+                      </p>
+
+                      <p
+                        style="
+                          margin: 0 0 20px 0;
+                          font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+                          font-size: 16px;
+                          line-height: 24px;
+                          color: #666666;
+                        "
+                        class="text-muted"
+                      >
+                        Thanks for your patience and interest in HopHacks!
+                        <br><br>
+                        The HopHacks Team
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Divider -->
+            <tr>
+              <td style="padding: 0 40px" class="mobile-padding bg-white">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td
+                      style="border-top: 1px solid #cccccc; padding: 15px 0"
+                      class="border-light-gray"
+                    ></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Footer -->
+            <tr>
+              <td
+                align="center"
+                style="padding: 0 40px 30px 40px"
+                class="mobile-padding bg-white"
+              >
+                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td align="center">
+                      <!-- Footer text -->
+                      <p
+                        style="
+                          margin: 0 0 15px 0;
+                          font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+                          font-size: 14px;
+                          line-height: 21px;
+                          color: #333333;
+                          text-align: center;
+                        "
+                        class="text-dark"
+                      >
+                        HopHacks {{ event_name }} | Johns Hopkins University<br />
+                        To contact us, please email
+                        <a
+                          href="mailto:hophacks@gmail.com"
+                          style="color: #333333; text-decoration: underline"
+                          class="text-dark"
+                        >hophacks@gmail.com</a>
+                      </p>
+
+                      <!-- Social links -->
+                      <p
+                        style="
+                          margin: 0;
+                          font-family:
+                            Arial, &quot;Helvetica Neue&quot;, Helvetica,
+                            sans-serif;
+                          font-size: 14px;
+                          line-height: 21px;
+                          color: #333333;
+                          text-align: center;
+                        "
+                        class="text-dark"
+                      >
+                        <a
+                          href="https://www.instagram.com/hophacks/?hl=en"
+                          target="_blank"
+                          style="color: #333333; text-decoration: underline"
+                          class="text-dark"
+                          >Instagram</a
+                        >
+                        |
+                        <a
+                          href="https://www.facebook.com/HopHacks/"
+                          target="_blank"
+                          style="color: #333333; text-decoration: underline"
+                          class="text-dark"
+                          >Facebook</a
+                        >
+                        |
+                        <a
+                          href="https://hophacks.com"
+                          target="_blank"
+                          style="color: #333333; text-decoration: underline"
+                          class="text-dark"
+                          >hophacks.com</a
+                        >
+                      </p>
+                    </td>
+                  </tr>
+                </table>
               </td>
             </tr>
           </table>

--- a/api/test/test_admin_users.py
+++ b/api/test/test_admin_users.py
@@ -21,3 +21,13 @@ def test_users_returns_current_event_registrants(client, test_db, test_mail):
     assert res.status_code == 200
     assert len(res.json['users']) == 1
     assert res.json['users'][0]['apply_at'] is not None
+
+
+def test_users_tolerates_missing_is_admin(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    # Regression: legacy docs without is_admin used to KeyError into a 500
+    test_db.users.update_one({'username': 'a@test.com'}, {'$unset': {'is_admin': ''}})
+    res = client.get('/api/admin/users', headers=bearer(admin))
+    assert res.status_code == 200
+    assert 'a@test.com' in [u['username'] for u in res.json['users']]

--- a/api/test/test_reg.py
+++ b/api/test/test_reg.py
@@ -97,3 +97,174 @@ def test_checkin_requires_admin(client, test_db, test_mail):
     uid = str(test_db.users.find_one({'username': 'a@test.com'})['_id'])
     res = client.post('/api/registrations/check_in', json={'user': uid}, headers=bearer(token))
     assert res.status_code == 401
+
+
+def _uid(test_db, username='a@test.com'):
+    return str(test_db.users.find_one({'username': username})['_id'])
+
+
+def test_accept_twice_sends_one_email(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    with test_mail.record_messages() as outbox:
+        client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert len(outbox) == 1
+        res = client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert res.status_code == 200
+        assert res.json['num_changed'] == 0
+        assert res.json['skipped'] == [uid]
+        assert len(outbox) == 1
+
+
+def test_accept_mixed_batch_emails_only_transitioned(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    register_confirmed(client, test_mail, create_json2)
+    admin = admin_token(client, test_db)
+    uid_a = _uid(test_db)
+    uid_b = _uid(test_db, 'b@test.com')
+
+    client.post('/api/registrations/accept', json={'users': [uid_a]}, headers=bearer(admin))
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/accept', json={'users': [uid_a, uid_b]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 1
+        assert res.json['skipped'] == [uid_a]
+        assert len(outbox) == 1
+        assert outbox[0].recipients == ['b@test.com']
+
+
+def test_accept_skips_rsvped(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+    user = login_token(client, login_json)
+    client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 0
+        assert len(outbox) == 0
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'rsvped'
+    assert reg['rsvp'] is True
+
+
+def test_waitlist_twice_sends_one_email(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    with test_mail.record_messages() as outbox:
+        client.post('/api/registrations/waitlist', json={'users': [uid]}, headers=bearer(admin))
+        assert len(outbox) == 1
+        res = client.post('/api/registrations/waitlist', json={'users': [uid]}, headers=bearer(admin))
+        assert res.status_code == 200
+        assert res.json['num_changed'] == 0
+        assert res.json['skipped'] == [uid]
+        assert len(outbox) == 1
+
+
+def test_waitlist_skips_rsvped(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+    user = login_token(client, login_json)
+    client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/waitlist', json={'users': [uid]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 0
+        assert len(outbox) == 0
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'rsvped'
+    assert reg['accept'] is True
+
+
+def test_reject_bulk_marks_and_emails(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    register_confirmed(client, test_mail, create_json2)
+    admin = admin_token(client, test_db)
+    ids = [_uid(test_db), _uid(test_db, 'b@test.com')]
+
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/reject', json={'users': ids}, headers=bearer(admin))
+        assert res.status_code == 200
+        assert res.json['num_changed'] == 2
+        assert len(outbox) == 2
+
+    for username in ('a@test.com', 'b@test.com'):
+        reg = _reg(test_db.users.find_one({'username': username}))
+        assert reg['status'] == 'rejected'
+        assert reg['accept'] is False
+
+
+def test_reject_clears_accept_and_blocks_rsvp(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+    client.post('/api/registrations/reject', json={'users': [uid]}, headers=bearer(admin))
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'rejected'
+    assert reg['accept'] is False
+
+    user = login_token(client, login_json)
+    res = client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+    assert res.status_code == 400
+
+
+def test_reject_twice_sends_one_email(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    with test_mail.record_messages() as outbox:
+        client.post('/api/registrations/reject', json={'users': [uid]}, headers=bearer(admin))
+        assert len(outbox) == 1
+        res = client.post('/api/registrations/reject', json={'users': [uid]}, headers=bearer(admin))
+        assert res.status_code == 200
+        assert res.json['num_changed'] == 0
+        assert res.json['skipped'] == [uid]
+        assert len(outbox) == 1
+
+
+def test_reject_skips_rsvped(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    register_confirmed(client, test_mail, create_json2)
+    admin = admin_token(client, test_db)
+    uid_a = _uid(test_db)
+    uid_b = _uid(test_db, 'b@test.com')
+    client.post('/api/registrations/accept', json={'users': [uid_a]}, headers=bearer(admin))
+    user = login_token(client, login_json)
+    client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/reject', json={'users': [uid_a, uid_b]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 1
+        assert res.json['skipped'] == [uid_a]
+        assert len(outbox) == 1
+
+    assert _reg(test_db.users.find_one({'username': 'a@test.com'}))['status'] == 'rsvped'
+    assert _reg(test_db.users.find_one({'username': 'b@test.com'}))['status'] == 'rejected'
+
+
+def test_rejected_then_accepted_allowed(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    with test_mail.record_messages() as outbox:
+        client.post('/api/registrations/reject', json={'users': [uid]}, headers=bearer(admin))
+        res = client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 1
+        assert len(outbox) == 2
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'accepted'
+    assert reg['accept'] is True

--- a/api/test/test_revert.py
+++ b/api/test/test_revert.py
@@ -1,0 +1,111 @@
+import sys
+sys.path.append('../src')
+
+from config.event import EVENT_NAME
+from utils import create_json, login_json
+from flow import register_confirmed, login_token, admin_token, bearer
+
+
+def _reg(user):
+    return next(r for r in user['registrations'] if r['event'] == EVENT_NAME)
+
+
+def _uid(test_db, username='a@test.com'):
+    return str(test_db.users.find_one({'username': username})['_id'])
+
+
+def test_revert_requires_admin(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    token = login_token(client, login_json)
+    uid = _uid(test_db)
+    res = client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(token))
+    assert res.status_code == 401
+
+
+def test_revert_accepted_resets_and_sends_no_email(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+
+    with test_mail.record_messages() as outbox:
+        res = client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(admin))
+        assert res.status_code == 200
+        assert res.json['num_changed'] == 1
+        assert len(outbox) == 0
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'applied'
+    assert reg['accept'] is False
+    assert 'accept_at' not in reg
+
+    user = login_token(client, login_json)
+    res = client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+    assert res.status_code == 400
+
+
+def test_revert_rsvped_resets_flags(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+    user = login_token(client, login_json)
+    client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(user))
+
+    res = client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(admin))
+    assert res.json['num_changed'] == 1
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'applied'
+    assert reg['rsvp'] is False
+    assert 'rsvp_time' not in reg
+
+    res = client.get('/api/registrations/rsvp/status', headers=bearer(user))
+    assert res.status_code == 200
+    assert res.json['status'] is False
+
+
+def test_revert_checked_in_resets(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+    client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+    client.post('/api/registrations/check_in', json={'user': uid}, headers=bearer(admin))
+
+    res = client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(admin))
+    assert res.json['num_changed'] == 1
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'applied'
+    assert reg['checkin'] is False
+    assert 'checkin_at' not in reg
+
+
+def test_revert_applied_is_skipped(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    res = client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(admin))
+    assert res.status_code == 200
+    assert res.json['num_changed'] == 0
+    assert res.json['skipped'] == [uid]
+
+
+def test_revert_then_accept_reissues_email(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    admin = admin_token(client, test_db)
+    uid = _uid(test_db)
+
+    with test_mail.record_messages() as outbox:
+        client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert len(outbox) == 1
+        client.post('/api/registrations/revert', json={'users': [uid]}, headers=bearer(admin))
+        assert len(outbox) == 1
+        res = client.post('/api/registrations/accept', json={'users': [uid]}, headers=bearer(admin))
+        assert res.json['num_changed'] == 1
+        assert len(outbox) == 2
+
+    reg = _reg(test_db.users.find_one({'username': 'a@test.com'}))
+    assert reg['status'] == 'accepted'
+    assert reg['accept'] is True

--- a/api/test/test_rsvp.py
+++ b/api/test/test_rsvp.py
@@ -62,3 +62,13 @@ def test_rsvp_view(client, test_db, test_mail):
     client.post('/api/registrations/rsvp/rsvp', json={'event': EVENT_NAME}, headers=bearer(token))
     res = client.get('/api/registrations/rsvp/view', headers=bearer(token))
     assert EVENT_NAME in res.json['rsvpList']
+
+
+def test_rsvp_status_with_no_registrations_returns_false(client, test_db, test_mail):
+    register_confirmed(client, test_mail, create_json)
+    token = login_token(client, login_json)
+    # Regression: an empty registrations list used to IndexError into a 500
+    test_db.users.update_one({'username': 'a@test.com'}, {'$set': {'registrations': []}})
+    res = client.get('/api/registrations/rsvp/status', headers=bearer(token))
+    assert res.status_code == 200
+    assert res.json['status'] is False

--- a/frontend/app/admin/panels/Applications.tsx
+++ b/frontend/app/admin/panels/Applications.tsx
@@ -5,9 +5,11 @@ import StatCard from "@/components/analytics/StatCard";
 import StatusBadge from "@/components/analytics/StatusBadge";
 import {
   AdminUser,
+  DecisionOutcome,
   accept,
   waitlist,
   reject,
+  revert,
   checkIn,
   deleteUser,
   openResume,
@@ -111,27 +113,66 @@ export default function ApplicationsPage() {
     }
   }
 
-  function bulk(action: "accept" | "waitlist" | "reject") {
+  async function runDecision(
+    verb: string,
+    fn: (ids: string[]) => Promise<DecisionOutcome>,
+    ids: string[],
+  ) {
+    setBusy((prev) => new Set([...prev, ...ids]));
+    setMessage("");
+    try {
+      const outcome = await fn(ids);
+      await load();
+      // Keep failed ids selected so one more click retries exactly those.
+      setSelected(new Set(outcome.failed));
+      const parts = [`${verb} ${outcome.num_changed}`];
+      if (outcome.skipped.length > 0)
+        parts.push(
+          `skipped ${outcome.skipped.length} (already decided or RSVP'd/checked in)`,
+        );
+      if (outcome.failed.length > 0)
+        parts.push(`failed ${outcome.failed.length}, kept selected — retry`);
+      setMessage(`${parts.join(" · ")}.`);
+    } catch {
+      setMessage("Action failed. Please try again.");
+    } finally {
+      setBusy((prev) => {
+        const next = new Set(prev);
+        ids.forEach((i) => next.delete(i));
+        return next;
+      });
+    }
+  }
+
+  const DECISIONS = {
+    accept: { verb: "Accepted", fn: accept, emails: true },
+    waitlist: { verb: "Waitlisted", fn: waitlist, emails: true },
+    reject: { verb: "Rejected", fn: reject, emails: true },
+    revert: { verb: "Reverted", fn: revert, emails: false },
+  } as const;
+
+  function bulk(action: keyof typeof DECISIONS) {
     const ids = [...selected];
     if (ids.length === 0) return;
-    const verb =
-      action === "accept"
-        ? "Accept"
-        : action === "waitlist"
-          ? "Waitlist"
-          : "Reject";
+    const { verb, fn, emails } = DECISIONS[action];
+    const warning = emails ? "This emails all of them." : "No emails are sent.";
     if (
       !window.confirm(
-        `${verb} ${ids.length} applicant(s)? This emails all of them.`,
+        `${verb.replace(/ed$/, "")} ${ids.length} applicant(s)? ${warning}`,
       )
     )
       return;
-    if (action === "accept")
-      run(`Accepted ${ids.length}.`, () => accept(ids), ids);
-    else if (action === "waitlist")
-      run(`Waitlisted ${ids.length}.`, () => waitlist(ids), ids);
-    else
-      run(`Rejected ${ids.length}.`, () => Promise.all(ids.map(reject)), ids);
+    runDecision(verb, fn, ids);
+  }
+
+  function rowDecision(action: keyof typeof DECISIONS, u: AdminUser) {
+    const { verb, fn, emails } = DECISIONS[action];
+    const name = `${field(u, "first_name")} ${field(u, "last_name")}`.trim();
+    const prompt = emails
+      ? `${verb.replace(/ed$/, "")} and email ${name} (${u.username})?`
+      : `Revert ${name} (${u.username}) to Applied? No email is sent.`;
+    if (!window.confirm(prompt)) return;
+    runDecision(verb, fn, [u.id]);
   }
 
   return (
@@ -214,6 +255,12 @@ export default function ApplicationsPage() {
             Reject
           </button>
           <button
+            className="rounded border border-slate-500 px-3 py-1 hover:bg-slate-700"
+            onClick={() => bulk("revert")}
+          >
+            Revert
+          </button>
+          <button
             className="ml-2 text-slate-300 hover:text-white"
             onClick={() => setSelected(new Set())}
           >
@@ -261,30 +308,21 @@ export default function ApplicationsPage() {
                       <button
                         disabled={isBusy}
                         className="rounded bg-green-600 px-2 py-1 text-white hover:bg-green-500 disabled:opacity-50"
-                        onClick={() =>
-                          run("Accepted.", () => accept([u.id]), [u.id])
-                        }
+                        onClick={() => rowDecision("accept", u)}
                       >
                         Accept
                       </button>
                       <button
                         disabled={isBusy}
                         className="rounded bg-amber-500 px-2 py-1 text-white hover:bg-amber-400 disabled:opacity-50"
-                        onClick={() =>
-                          run("Waitlisted.", () => waitlist([u.id]), [u.id])
-                        }
+                        onClick={() => rowDecision("waitlist", u)}
                       >
                         Waitlist
                       </button>
                       <button
                         disabled={isBusy}
                         className="rounded bg-red-600 px-2 py-1 text-white hover:bg-red-500 disabled:opacity-50"
-                        onClick={() => {
-                          if (
-                            window.confirm("Reject and email this applicant?")
-                          )
-                            run("Rejected.", () => reject(u.id), [u.id]);
-                        }}
+                        onClick={() => rowDecision("reject", u)}
                       >
                         Reject
                       </button>
@@ -296,6 +334,13 @@ export default function ApplicationsPage() {
                         }
                       >
                         Check in
+                      </button>
+                      <button
+                        disabled={isBusy}
+                        className="rounded border border-slate-300 px-2 py-1 text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                        onClick={() => rowDecision("revert", u)}
+                      >
+                        Revert
                       </button>
                       {u.resume ? (
                         <button

--- a/frontend/app/admin/panels/Applications.tsx
+++ b/frontend/app/admin/panels/Applications.tsx
@@ -131,7 +131,7 @@ export default function ApplicationsPage() {
           `skipped ${outcome.skipped.length} (already decided or RSVP'd/checked in)`,
         );
       if (outcome.failed.length > 0)
-        parts.push(`failed ${outcome.failed.length}, kept selected — retry`);
+        parts.push(`failed ${outcome.failed.length}, kept selected for retry`);
       setMessage(`${parts.join(" · ")}.`);
     } catch {
       setMessage("Action failed. Please try again.");

--- a/frontend/app/util/adminApi.ts
+++ b/frontend/app/util/adminApi.ts
@@ -45,15 +45,43 @@ export async function getUsers(query = ""): Promise<AdminUser[]> {
   return r.data.users ?? [];
 }
 
+export type DecisionOutcome = {
+  num_changed: number;
+  skipped: string[];
+  failed: string[];
+};
+
+/* One request must stay well under API Gateway's 29s cap since the backend
+   sends decision emails synchronously; 20 ids per chunk is a wide margin. */
+const DECISION_CHUNK = 20;
+
+async function postDecision(
+  path: string,
+  ids: string[],
+): Promise<DecisionOutcome> {
+  const outcome: DecisionOutcome = { num_changed: 0, skipped: [], failed: [] };
+  for (let i = 0; i < ids.length; i += DECISION_CHUNK) {
+    const chunk = ids.slice(i, i + DECISION_CHUNK);
+    try {
+      const r = await axios.post(path, { users: chunk, event: CURRENT_EVENT });
+      outcome.num_changed += r.data.num_changed ?? 0;
+      outcome.skipped.push(...(r.data.skipped ?? []));
+    } catch {
+      outcome.failed.push(...chunk);
+    }
+  }
+  return outcome;
+}
+
 export const accept = (ids: string[]) =>
-  axios.post("/api/registrations/accept", { users: ids, event: CURRENT_EVENT });
+  postDecision("/api/registrations/accept", ids);
 export const waitlist = (ids: string[]) =>
-  axios.post("/api/registrations/waitlist", {
-    users: ids,
-    event: CURRENT_EVENT,
-  });
-export const reject = (id: string) =>
-  axios.post("/api/registrations/reject", { user: id, event: CURRENT_EVENT });
+  postDecision("/api/registrations/waitlist", ids);
+export const reject = (ids: string[]) =>
+  postDecision("/api/registrations/reject", ids);
+/** Reset registrations to "applied" without emailing (misclick recovery). */
+export const revert = (ids: string[]) =>
+  postDecision("/api/registrations/revert", ids);
 export const checkIn = (id: string) =>
   axios.post("/api/registrations/check_in", { user: id, event: CURRENT_EVENT });
 

--- a/frontend/tests/e2e/admin-console.spec.ts
+++ b/frontend/tests/e2e/admin-console.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Stubbed-backend specs for the admin console decision flow (accept /
+// revert, confirm dialogs, request chunking). Mirrors account-flows.spec.ts:
+// these exercise the page contracts; the decision semantics themselves are
+// covered by the API's pytest suite.
+
+const EMPTY_STATS = {
+  total: 0,
+  by_status: {},
+  by_school: {},
+  by_level_of_study: {},
+  by_country: {},
+  by_gender: {},
+  by_race_ethnicity: {},
+};
+
+function makeUser(id: string, first: string, last: string, status: string) {
+  return {
+    id,
+    username: `${first.toLowerCase()}@e2e.com`,
+    profile: { first_name: first, last_name: last, school: "JHU" },
+    email_confirmed: true,
+    registrations: [{ event: "Fall 2026", status }],
+    resume: null,
+    apply_at: null,
+  };
+}
+
+async function stubAdminConsole(page: Page, statuses: Map<string, string>) {
+  await page.route("**/api/auth/session/refresh", (r) =>
+    r.fulfill({ json: { access_token: "stub-token" } }),
+  );
+  await page.route("**/api/admin/", (r) =>
+    r.fulfill({ json: { is_admin: true } }),
+  );
+  await page.route("**/api/admin/stats", (r) =>
+    r.fulfill({ json: EMPTY_STATS }),
+  );
+  await page.route("**/api/admin/users*", (r) =>
+    r.fulfill({
+      json: {
+        users: [...statuses].map(([id, status], i) =>
+          makeUser(id, `User${i}`, "Tester", status),
+        ),
+      },
+    }),
+  );
+}
+
+async function openApplications(page: Page) {
+  await page.goto("/admin");
+  await page.getByRole("button", { name: "Applications" }).click();
+}
+
+test("admin accepts an applicant who RSVPs; revert returns them to Applied", async ({
+  page,
+}) => {
+  const statuses = new Map([["id-ada", "applied"]]);
+  await stubAdminConsole(page, statuses);
+
+  const dialogs: string[] = [];
+  page.on("dialog", (d) => {
+    dialogs.push(d.message());
+    d.accept();
+  });
+
+  const acceptCall: { payload?: { users?: string[]; event?: string } } = {};
+  await page.route("**/api/registrations/accept", async (r) => {
+    acceptCall.payload = r.request().postDataJSON();
+    statuses.set("id-ada", "accepted");
+    await r.fulfill({
+      json: { num_changed: 1, skipped: [], email_failures: 0 },
+    });
+  });
+
+  await openApplications(page);
+  await expect(page.locator("tbody").getByText("Applied")).toBeVisible();
+
+  await page.getByRole("button", { name: "Accept", exact: true }).click();
+  await expect(
+    page.locator("tbody").getByText("Accepted", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Accepted 1.")).toBeVisible();
+  expect(acceptCall.payload).toEqual({
+    users: ["id-ada"],
+    event: "Fall 2026",
+  });
+  expect(dialogs[0]).toContain("Accept and email User0 Tester");
+
+  // The accepted user sees the status on their profile and can RSVP.
+  await page.route("**/api/accounts/profile/get", (r) =>
+    r.fulfill({ json: { profile: { first_name: "User0" } } }),
+  );
+  await page.route("**/api/resumes/filename", (r) =>
+    r.fulfill({ json: { filename: "resume.pdf" } }),
+  );
+  await page.route("**/api/accounts/profile/email_confirmed", (r) =>
+    r.fulfill({ json: { email_confirmed: true } }),
+  );
+  await page.route("**/api/registrations/get", (r) =>
+    r.fulfill({
+      json: {
+        registrations: [{ event: "Fall 2026", status: statuses.get("id-ada") }],
+      },
+    }),
+  );
+  await page.route("**/api/registrations/rsvp/rsvp", async (r) => {
+    statuses.set("id-ada", "rsvped");
+    await r.fulfill({ json: { msg: "success" } });
+  });
+
+  await page.goto("/profile");
+  await expect(page.getByText("Accepted", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "RSVP now" }).click();
+  await expect(page.getByText("RSVP'd", { exact: true })).toBeVisible();
+
+  // Back in the console, revert silently resets the misclick.
+  const revertCall: { payload?: unknown } = {};
+  await page.route("**/api/registrations/revert", async (r) => {
+    revertCall.payload = r.request().postDataJSON();
+    statuses.set("id-ada", "applied");
+    await r.fulfill({
+      json: { num_changed: 1, skipped: [], email_failures: 0 },
+    });
+  });
+
+  await openApplications(page);
+  await expect(page.locator("tbody").getByText("RSVP'd")).toBeVisible();
+  await page.getByRole("button", { name: "Revert", exact: true }).click();
+  await expect(page.locator("tbody").getByText("Applied")).toBeVisible();
+  await expect(page.getByText("Reverted 1.")).toBeVisible();
+  expect(revertCall.payload).toEqual({
+    users: ["id-ada"],
+    event: "Fall 2026",
+  });
+  expect(dialogs[dialogs.length - 1]).toContain("No email is sent");
+});
+
+test("a dismissed confirm dialog sends nothing", async ({ page }) => {
+  const statuses = new Map([["id-ada", "applied"]]);
+  await stubAdminConsole(page, statuses);
+  page.on("dialog", (d) => d.dismiss());
+
+  let acceptCalls = 0;
+  await page.route("**/api/registrations/accept", async (r) => {
+    acceptCalls += 1;
+    await r.fulfill({
+      json: { num_changed: 1, skipped: [], email_failures: 0 },
+    });
+  });
+
+  await openApplications(page);
+  await page.getByRole("button", { name: "Accept", exact: true }).click();
+
+  await expect(page.locator("tbody").getByText("Applied")).toBeVisible();
+  expect(acceptCalls).toBe(0);
+});
+
+test("bulk accept chunks into requests of 20", async ({ page }) => {
+  const statuses = new Map(
+    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"] as const),
+  );
+  await stubAdminConsole(page, statuses);
+  page.on("dialog", (d) => d.accept());
+
+  const chunkSizes: number[] = [];
+  await page.route("**/api/registrations/accept", async (r) => {
+    const users: string[] = r.request().postDataJSON().users;
+    chunkSizes.push(users.length);
+    users.forEach((id) => statuses.set(id, "accepted"));
+    await r.fulfill({
+      json: { num_changed: users.length, skipped: [], email_failures: 0 },
+    });
+  });
+
+  await openApplications(page);
+  for (const box of await page.locator("tbody input[type=checkbox]").all())
+    await box.check();
+  await expect(page.getByText("25 selected")).toBeVisible();
+
+  await page
+    .locator("div.bg-slate-800")
+    .getByRole("button", { name: "Accept" })
+    .click();
+
+  await expect(page.getByText("Accepted 25.")).toBeVisible();
+  expect(chunkSizes).toEqual([20, 5]);
+});
+
+test("partial failure is reported and failed rows stay selected", async ({
+  page,
+}) => {
+  const statuses = new Map(
+    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"] as const),
+  );
+  await stubAdminConsole(page, statuses);
+  page.on("dialog", (d) => d.accept());
+
+  let call = 0;
+  await page.route("**/api/registrations/accept", async (r) => {
+    call += 1;
+    if (call > 1) {
+      await r.fulfill({ status: 500, json: { msg: "boom" } });
+      return;
+    }
+    const users: string[] = r.request().postDataJSON().users;
+    users.forEach((id) => statuses.set(id, "accepted"));
+    await r.fulfill({
+      json: { num_changed: users.length, skipped: [], email_failures: 0 },
+    });
+  });
+
+  await openApplications(page);
+  for (const box of await page.locator("tbody input[type=checkbox]").all())
+    await box.check();
+  await page
+    .locator("div.bg-slate-800")
+    .getByRole("button", { name: "Accept" })
+    .click();
+
+  await expect(
+    page.getByText("Accepted 20 · failed 5, kept selected for retry."),
+  ).toBeVisible();
+  await expect(page.locator("tbody input[type=checkbox]:checked")).toHaveCount(
+    5,
+  );
+});


### PR DESCRIPTION
## Why

Acceptances start today. The decision endpoints emailed every requested user even when nothing changed (repeat clicks and mixed batches double-emailed applicants), reject left the `accept` flag set so an accepted-then-rejected user could still RSVP, and per-row Accept/Waitlist fired an email on a bare click with no confirmation. Bulk accepts also sent all emails inside one Lambda request, risking the 29s API Gateway timeout mid-batch.

## What

**Backend (`api/src/registrations.py`)**
- `apply_decision` helper: the status guard lives inside each atomic `find_one_and_update` filter, so accept/waitlist/reject only transition (and only email) eligible users. Repeat requests are no-ops. `rsvped`/`checked_in` are never touched by decision endpoints.
- `/reject` clears `accept`, gains bulk `{users: [...]}` input (legacy `{user}` still works), and its sender is pluralized.
- New admin-only `POST /registrations/revert`: silently resets registrations to the fresh `applied` shape (no email); the recovery path for misclicks and the only exit from `rsvped`/`checked_in`.
- Responses add `skipped` ids and `email_failures` (one bad address no longer aborts the batch); `num_changed` is preserved.
- Fixes: `/rsvp/status` 500 on empty registrations; `/api/admin/users` 500 on legacy docs missing `is_admin`.

**Emails**: `email_waitlist.html` rebuilt on the acceptance skeleton so it carries the same header/dates/footer chrome as the other decision emails.

**Frontend (`adminApi.ts`, `Applications.tsx`)**
- Decision requests go out in chunks of 20; results report accepted/skipped/failed, and failed ids stay selected for one-click retry.
- Confirm dialogs on every decision button (with the applicant's name/email); Revert button per-row and in the bulk bar.

**Tests**: 20 new pytest cases (idempotency, reject-clears-accept, revert semantics, regressions); full suite 109 passed. New `admin-console.spec.ts` Playwright spec (4 tests); full e2e suite 23 passed. Manually click-tested against the local stack: accept, re-accept skip, RSVP, reject-blocked-on-rsvped, revert, reject, RSVP-blocked.

## Deploy note

Backend is backward compatible with the old frontend, but the new frontend calls `/revert` and bulk reject, so let the Lambda deploy finish before relying on the new Vercel build (minutes at worst). Emails send after the DB write: if SMTP fails mid-batch, statuses are correct, `email_failures` reports it, and re-clicking is safe (no double-emails). Reminder: the sender is a free Gmail account (~500 recipients/day).