### PR TITLE
fix: current-year links and subject casing in RSVP email

### DIFF
--- a/api/src/registrations.py
+++ b/api/src/registrations.py
@@ -46,7 +46,7 @@ def send_rsvp_info(users):
      with mail.connect() as conn:
         for user in users:
             email = user["username"]
-            subject = "RSVP Event Info - Hophacks.com"
+            subject = "RSVP Event Info - HopHacks.com"
             msg = Message(recipients=[email],
                           subject=subject)
 
@@ -75,7 +75,7 @@ def _send_decision_emails(users, subject, body, template):
 def send_acceptances(users):
     return _send_decision_emails(
         users,
-        "Acceptance Letter - Hophacks.com",
+        "Acceptance Letter - HopHacks.com",
         'Congrats on being accepted to HopHacks!',
         'email_acceptance.html')
 

--- a/api/src/templates/rsvpinfo.html
+++ b/api/src/templates/rsvpinfo.html
@@ -285,7 +285,7 @@
                       <div class="info-section">
                         <p class="info-title">Discord:</p>
                         <p class="info-content">
-                          Please join the HopHacks {{ event_name }} Discord <a href="http://discord.gg/8V8wmCWUhH" style="color: #0066cc; text-decoration: underline;">here</a> for the latest updates and announcements. You can get a head start on team forming if needed, and ask questions you may have!
+                          Please join the HopHacks {{ event_name }} Discord <a href="https://discord.gg/xx2nYA6zJ" style="color: #0066cc; text-decoration: underline;">here</a> for the latest updates and announcements. You can get a head start on team forming if needed, and ask questions you may have!
                         </p>
                       </div>
 
@@ -310,14 +310,6 @@
                         <p class="info-title">Identification:</p>
                         <p class="info-content">
                           Please bring a form of ID, such as a school ID, driver's license, or passport. We will check these during check-in.
-                        </p>
-                      </div>
-
-                      <!-- Transportation -->
-                      <div class="info-section">
-                        <p class="info-title">Transportation:</p>
-                        <p class="info-content">
-                          Please fill out the busing form <a href="https://forms.gle/yte2ZZSqSZ3GnERv5" style="color: #0066cc; text-decoration: underline;">here</a> if you are interested in a bus coming to your school or city! We cannot guarantee busing, but we will aim to let you know a few weeks before the hackathon so you can make alternate arrangements.
                         </p>
                       </div>
 


### PR DESCRIPTION
## Why

The RSVP info email (sent on every RSVP) linked the HopHacks Fall 2025 Discord server and the Fall 2025 busing interest form, which is still accepting responses. With acceptances and RSVPs starting today, RSVPers would land in last year's server and submit last year's form.

## What

- Discord invite in `rsvpinfo.html` now points at the HopHacks 2026 server (`discord.gg/xx2nYA6zJ`).
- Transportation/busing section removed; busing isn't offered this cycle.
- Subject casing: "Acceptance Letter - HopHacks.com" and "RSVP Event Info - HopHacks.com" (were lowercase "Hophacks.com", inconsistent with every other email).

## Note

The new Discord invite expires 2026-09-02 (30-day invite), before the event on September 18-20. Regenerate it as never-expiring in Discord and update the link before then, or attendees re-opening this email for logistics will hit a dead invite.

Verified: template renders with the new link and no busing remnants; test_reg/test_rsvp/test_revert all pass (29).