### PR TITLE
fix: never-expiring Discord invite in RSVP email

### DIFF
--- a/api/src/templates/rsvpinfo.html
+++ b/api/src/templates/rsvpinfo.html
@@ -285,7 +285,7 @@
                       <div class="info-section">
                         <p class="info-title">Discord:</p>
                         <p class="info-content">
-                          Please join the HopHacks {{ event_name }} Discord <a href="https://discord.gg/xx2nYA6zJ" style="color: #0066cc; text-decoration: underline;">here</a> for the latest updates and announcements. You can get a head start on team forming if needed, and ask questions you may have!
+                          Please join the HopHacks {{ event_name }} Discord <a href="https://discord.gg/Ydbzhqkkhp" style="color: #0066cc; text-decoration: underline;">here</a> for the latest updates and announcements. You can get a head start on team forming if needed, and ask questions you may have!
                         </p>
                       </div>
 


### PR DESCRIPTION
The invite added in #488 expires 2026-09-02, before the event (September 18-20); attendees re-open the RSVP email for logistics the week of the hackathon. This one is verified against the Discord API: HopHacks 2026 server, no expiry, auto-assigns the hacker role.