### PR TITLE
fix: cap school datalist to stop mobile signup crash

### DIFF
--- a/frontend/app/components/form/Combobox.tsx
+++ b/frontend/app/components/form/Combobox.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
+
+/* Mobile Safari hangs or crashes the tab when a <datalist> holds thousands
+   of options (the schools list is ~9.7k), so only a capped, pre-filtered
+   slice is ever mounted; the browser then matches within that slice. */
+const MAX_VISIBLE_OPTIONS = 50;
 
 const INPUT_CLS = "input-sketch w-full rounded-lg px-4 py-2.5 text-base";
 
@@ -41,6 +46,13 @@ export default function Combobox({
     }
   }
 
+  const visible = useMemo(() => {
+    const all = loaded ?? [];
+    const q = value.trim().toLowerCase();
+    const matches = q ? all.filter((o) => o.toLowerCase().includes(q)) : all;
+    return matches.slice(0, MAX_VISIBLE_OPTIONS);
+  }, [loaded, value]);
+
   return (
     <>
       <input
@@ -55,7 +67,7 @@ export default function Combobox({
         autoComplete="off"
       />
       <datalist id={listId}>
-        {(loaded ?? []).map((opt) => (
+        {visible.map((opt) => (
           <option key={opt} value={opt} />
         ))}
       </datalist>

--- a/frontend/tests/e2e/admin-console.spec.ts
+++ b/frontend/tests/e2e/admin-console.spec.ts
@@ -158,8 +158,8 @@ test("a dismissed confirm dialog sends nothing", async ({ page }) => {
 });
 
 test("bulk accept chunks into requests of 20", async ({ page }) => {
-  const statuses = new Map(
-    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"] as const),
+  const statuses = new Map<string, string>(
+    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"]),
   );
   await stubAdminConsole(page, statuses);
   page.on("dialog", (d) => d.accept());
@@ -191,8 +191,8 @@ test("bulk accept chunks into requests of 20", async ({ page }) => {
 test("partial failure is reported and failed rows stay selected", async ({
   page,
 }) => {
-  const statuses = new Map(
-    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"] as const),
+  const statuses = new Map<string, string>(
+    Array.from({ length: 25 }, (_, i) => [`id-${i}`, "applied"]),
   );
   await stubAdminConsole(page, statuses);
   page.on("dialog", (d) => d.accept());


### PR DESCRIPTION
## Why

An applicant emailed that signup crashes whenever they enter their school and they can't proceed. The school field mounts all ~9,660 school options into a native `<datalist>` on first focus and re-reconciles them on every keystroke. Desktop browsers absorb it (couldn't repro in Chromium); mobile Safari is known to hang or kill the tab on datalists that size, which matches the report.

## What

`Combobox` now renders only a pre-filtered slice of at most 50 options (case-insensitive substring on the current input); the full list stays in memory. The browser still does its own matching within the slice, so desktop behavior is unchanged.

Verified in-browser: empty focus mounts 50 options (was 9,660), typing "Johns" mounts 10 with Johns Hopkins University present, "Other (not listed)" remains findable. `tsc` clean, all 23 Playwright tests pass (the registration spec exercises this field).

Also pins the admin e2e spec's status Maps to `Map<string, string>` to fix a type error tsc caught after the fact.